### PR TITLE
Allow subsecond maxtimes for ExponentialBackoff

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,10 @@ ENV/
 
 # Rope project settings
 .ropeproject
+
+# pycharm project
+.idea
+
+# direnv
+.direnv
+.envrc

--- a/riprova/strategies/exponential.py
+++ b/riprova/strategies/exponential.py
@@ -90,7 +90,7 @@ class ExponentialBackOff(Backoff):
         assert isinstance(interval, (int, float)), INT_ERROR.format('interval')
         assert isinstance(multiplier, (int, float)), INT_ERROR.format('multiplier')  # noqa
         assert isinstance(factor, (int, float)), INT_ERROR.format('factor')
-        assert isinstance(max_elapsed, int), INT_ERROR.format('max_elapsed')
+        assert isinstance(max_elapsed, (int, float)), INT_ERROR.format('max_elapsed')
         assert isinstance(max_interval, int), INT_ERROR.format('max_interval')
         assert interval >= 0, POS_ERROR.format('interval')
         assert multiplier >= 0, POS_ERROR.format('multiplier')


### PR DESCRIPTION
Especially useful when running backoffs in tests, where long backoff time is not desired.